### PR TITLE
Remove warnings, adapt for Xenial, improve Mesos support

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -43,3 +43,4 @@
     - 'role::airflow'
     - 'role::airflow::config'
     - 'role::airflow::install'
+

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -87,3 +87,4 @@
   when:
     - "airflow_config_stat.stat.exists"
     - "airflow_do_upgrade_db | bool"
+

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -54,3 +54,13 @@
     virtualenv: "{{ airflow_virtualenv }}"
     virtualenv_python: "{{ airflow_python_version }}"
   with_items: "{{ airflow_extra_packages }}"
+
+# Link Mesos Python bindings in the virtualenv sandbox
+- name: 'Manage mesos python bindings'
+  become: True
+  become_user: "{{ airflow_user_name }}"
+  file:
+    src: "{{ airflow_mesos_python_bindings_path }}/mesos"
+    dest: "{{ airflow_virtualenv }}/lib/{{ airflow_python_version }}/site-packages/mesos"
+    state: 'link'
+  when: "airflow_mesos_python_bindings_path is not none"

--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -1,0 +1,12 @@
+---
+
+# Ubuntu specific values
+
+airflow_default_system_dependencies:
+  - name: "{{ airflow_python_version }}-dev"
+  - name: 'libpq-dev'
+  - name: 'libssl-dev'
+  - name: 'libffi-dev'
+  - name: 'build-essential'
+  - name: 'python-virtualenv'
+  - name: 'python-pip'

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -1,0 +1,12 @@
+---
+
+# Ubuntu specific values
+
+airflow_default_system_dependencies:
+  - name: "{{ airflow_python_version }}-dev"
+  - name: 'libpq-dev'
+  - name: 'libssl-dev'
+  - name: 'libffi-dev'
+  - name: 'build-essential'
+  - name: 'virtualenv'
+  - name: 'python-pip'


### PR DESCRIPTION
This PR addresses three points:
1) Remove warnings that pop up regarding the usage of brackets
2) Make the role work on both Trusty _and_ Xenial (in the former everything needed is part of `python-virtualenv` while in the latter executables are part of the `virtualenv` package - that in turn depends on `python-virtualenv`, that comes without executables)
3) Improve Mesos support by adding the possibility to link Mesos Python bindings into the `virtualenv` instance (`mesos.native` unfortunately is not available on PyPi and cannot be installed with `pip` into the `virtualenv` environment).

I hope this PR can be of some help, I'm open for discussion should I got any point wrong.