### PR TITLE
Fix airflow_user_config must use combine with recursive set to True

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,7 +155,7 @@ airflow_defaults_config:
     default_secret: 'admin'
 
 airflow_user_config: {}
-airflow_config: "{{ airflow_defaults_config | combine(airflow_user_config) }}"
+airflow_config: "{{ airflow_defaults_config | combine(airflow_user_config, recursive=True) }}"
 
 # Logrotate configuration
 airflow_logrotate_config:


### PR DESCRIPTION
so override is possible:
```yaml
airflow_user_config:
  core:
    dags_folder: '/home/ubuntu/airflow/dags'
```