### PR TITLE
adding task for systemctl daemon-reload

### DIFF
--- a/tasks/manage_services.yml
+++ b/tasks/manage_services.yml
@@ -34,8 +34,14 @@
     group: "{{ item.group | default('root') }}"
     mode: "{{ item.mode | default('0644') }}"
   notify: "{{ item.handler }}"
+  register: airflow_systemd_updated
   with_items: "{{ airflow_services_systemd }}"
   when: "is_systemd_managed_system | bool"
+
+- name: 'SERVICE | systemd daemon-reload'
+  systemd:
+    daemon_reload: true
+  when: "(is_systemd_managed_system | bool) and (airflow_systemd_updated.changed | bool)"
 
 
 - name: 'SERVICE | Manage services with init.d'


### PR DESCRIPTION
Fixes #39 

Detects changes in systemd services, and performs a systemd `systemctl daemon-reload` via Ansible's `systemd` command.