### PR TITLE
Directory environment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,12 @@ airflow_system_dependencies: "{{ _airflow_system_dependencies }}"
 # Always changed with airflow and airflow[crypto]
 airflow_pip_changed_when: False
 
+# Ansible's pip module doesn't currently support complex version strings
+# https://github.com/ansible/ansible/issues/19321
+# And Airflow may currently require custom version strings
+# https://stackoverflow.com/a/48075827
+airflow_pip_custom_version_install: False
+
 # Installation vars
 airflow_user_name: 'airflow'
 airflow_user_group: "{{ airflow_user_name }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,10 @@ airflow_packages:
 airflow_extra_packages:
   - name: 'apache-airflow[crypto]'
 
+# option to set environment for all users,
+# by providing a file in /etc/profile.d/
+airflow_provide_user_env: False
+
 
 # SERVICES MANAGEMENT
 # -----------------------------------------------------------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,8 @@
 # Installation tasks management
 - name: 'INSTALL | Include installation tasks'
   include: "{{ role_path }}/tasks/manage_installation.yml"
+  environment:
+    AIRFLOW_HOME: '{{ airflow_config.core.airflow_home }}'
   become: True
   tags:
     - 'role::airflow'
@@ -22,6 +24,8 @@
 # Configuration tasks management
 - name: 'CONFIG | Include configuration tasks'
   include: "{{ role_path }}/tasks/manage_configuration.yml"
+  environment:
+    AIRFLOW_HOME: '{{ airflow_config.core.airflow_home }}'
   become: True
   tags:
     - 'role::airflow'
@@ -42,7 +46,7 @@
 - name: 'CONFIG | Include connections tasks'
   include: "{{ role_path }}/tasks/manage_connections.yml"
   environment:
-    AIRFLOW_CONFIG: '/var/lib/airflow/airflow/airflow.cfg'
+    AIRFLOW_HOME: '{{ airflow_config.core.airflow_home }}'
   become: True
   tags:
     - 'role::airflow'
@@ -53,7 +57,7 @@
 - name: 'CONFIG | Include connections tasks'
   include: "{{ role_path }}/tasks/manage_airflow_variables.yml"
   environment:
-    AIRFLOW_CONFIG: '/var/lib/airflow/airflow/airflow.cfg'
+    AIRFLOW_HOME: '{{ airflow_config.core.airflow_home }}'
   become: True
   tags:
     - 'role::airflow'

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -2,24 +2,6 @@
 
 # Airflow configuration tasks
 
-# Check if configuration file exists
-- name: 'CONFIG | Check if configuration file exists'
-  stat:
-    path: "{{ airflow_config.core.airflow_home }}/airflow.cfg"
-  register: 'airflow_config_stat'
-  changed_when: False
-
-
-# Create airflow directory
-- name: 'CONFIG | Create root airflow directory'
-  file:
-    path: "{{ airflow_config.core.airflow_home }}"
-    owner: "{{ airflow_user_name }}"
-    group: "{{ airflow_user_group }}"
-    mode: '0700'
-    state: 'directory'
-
-
 # Manage configuration templating
 - name: 'CONFIG | Manage configuration templating'
   become_user: "{{ airflow_user_name }}"

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -64,6 +64,14 @@
     state: directory
 
 
+# setup environment for all users, AIRFLOW_HOME, etc
+- name: 'INSTALL | Manage /etc/profile.d/ file'
+  template:
+    src: "{{ role_path }}/templates/airflow.profile.j2"
+    dest: "/etc/profile.d/airflow.sh"
+  when: airflow_provide_user_env
+
+
 # Install airflow packages
 - name: 'INSTALL | Manage airflow installation'
   become_user: "{{ airflow_user_name }}"

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -83,6 +83,22 @@
     virtualenv_python: "{{ airflow_python_version }}"
   changed_when: "airflow_pip_changed_when"
   with_items: "{{ airflow_packages }}"
+  when: (not airflow_pip_custom_version_install) or
+      (item.version is not defined) or 
+      ( (not item.version | search('<') ) and (not item.version | search('>') ) )
+
+
+# Install airflow packages
+# Ansible's pip module doesn't currently support complex version strings
+# https://github.com/ansible/ansible/issues/19321
+- name: 'INSTALL | Manage airflow installation - complex pip versions'
+  become_user: "{{ airflow_user_name }}"
+  command: "{{ airflow_virtualenv }}/bin/pip install '{{ item.name }}{{ item.version }}'"
+  changed_when: "airflow_pip_changed_when"
+  with_items: "{{ airflow_packages }}"
+  when: (airflow_pip_custom_version_install) and
+        (item.version is defined) and 
+      ( (item.version | search('<') ) or (item.version | search('>') ) )
 
 
 # Install airflow extra packages

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -20,6 +20,15 @@
     shell: "{{ airflow_user_shell }}"
 
 
+# Check if configuration file exists
+# This has to happen before the install, because the install creates a default file in $AIRFLOW_HOME
+- name: 'INSTALL | Check if configuration file exists'
+  stat:
+    path: "{{ airflow_config.core.airflow_home }}/airflow.cfg"
+  register: 'airflow_config_stat'
+  changed_when: False
+
+
 - name: 'INSTALL | Manage permissions on user home directory'
   file:
     path: "{{ airflow_user_home_path }}"
@@ -39,19 +48,19 @@
 
 - name: 'INSTALL | Manage permissions on airflow home directory'
   file:
-    path: "{{ airflow_defaults_config.core.airflow_home }}"
+    path: "{{ airflow_config.core.airflow_home }}"
     owner: "{{ airflow_user_name }}"
     group: "{{ airflow_user_name }}"
-    mode: "{{ airflow_defaults_config.core.airflow_home_mode }}"
+    mode: "{{ airflow_config.core.airflow_home_mode }}"
     state: directory
 
 
 - name: 'INSTALL | Manage permissions on airflow dags directory'
   file:
-    path: "{{ airflow_defaults_config.core.dags_folder }}"
+    path: "{{ airflow_config.core.dags_folder }}"
     owner: "{{ airflow_user_name }}"
     group: "{{ airflow_user_name }}"
-    mode: "{{ airflow_defaults_config.core.dags_folder_mode }}"
+    mode: "{{ airflow_config.core.dags_folder_mode }}"
     state: directory
 
 

--- a/templates/airflow.profile.j2
+++ b/templates/airflow.profile.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+# General
+export AIRFLOW_HOME="{{ airflow_config.core.airflow_home }}"
+export PATH="$PATH:{{ airflow_virtualenv ~ '/bin' }}"


### PR DESCRIPTION
Following on #41, some additional tasks needed to be modified to support custom install locations.

While investigating this, I added two optional features (disabled by default, controlled via variables) that
1. Installs a file in `/etc/profile.d` to provide Airflow environment variables to all users
1. Can `pip install` custom versions of software, which is not currently supported in Ansible's `pip` module.