### PR TITLE
Add ~/bin to scheduler $PATH

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,7 +85,7 @@ airflow_services_systemd:
       Install:
         WantedBy: 'multi-user.target'
       Service:
-        Environment: "PATH={{ airflow_virtualenv ~ '/bin' }}"
+        Environment: "PATH={{ airflow_virtualenv ~ '/bin' }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         EnvironmentFile: "{{ airflow_paths.files.environment.path }}"
         ExecStart: "{{ airflow_virtualenv ~ '/bin' }}/airflow scheduler"
         Group: "{{ airflow_user_group }}"

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -22,6 +22,7 @@
     group: "{{ airflow_log_group }}"
     mode: "{{ airflow_log_mode }}"
     state: 'directory'
+    recurse: yes
 
 
 # Manage pid folder
@@ -32,6 +33,7 @@
     group: "{{ airflow_pid_group }}"
     mode: "{{ airflow_pid_mode }}"
     state: 'directory'
+    recurse: yes
 
 
 # Manage logrotate configuration


### PR DESCRIPTION
Hey,
the LocalExecutor will not work unless you add paths to the machines binaries, specifically bash.
Hence this PR